### PR TITLE
Define "Bundle Display Name" para "CocoaHeads" e adiciona badge do Waffle no README

### DIFF
--- a/CocoaHeadsApp/CocoaHeadsApp/Info.plist
+++ b/CocoaHeadsApp/CocoaHeadsApp/Info.plist
@@ -46,6 +46,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleDisplayName</key>
+	<string>CocoaHeads</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # CocoaHeads Brasil 🇧🇷
+
+[![waffle board](https://img.shields.io/badge/waffle-board-blue.svg)](https://waffle.io/CocoaHeadsBrasil/CocoaHeadsApp)
+
 ## Guidelines para desenvolver novas features do app
+
 #### UI
 Usamos um storyboard **Main.storyboard** para definir o fluxo do app, porém o desenvolvimento da tela não é feito diretamente no storyboard. Para desenvolver uma tela você deve:
 


### PR DESCRIPTION
Antes era o default (nome do projeto) "CocoaHeadsApp" e não cabia, ficando com as reticências.
