### PR TITLE
Força versão do Unbox para 1.0

### DIFF
--- a/CocoaHeadsApp/Podfile
+++ b/CocoaHeadsApp/Podfile
@@ -2,7 +2,7 @@ platform :ios, '8.0'
 use_frameworks!
 
 pod 'R.swift'
-pod 'Unbox', :git => 'https://github.com/JohnSundell/Unbox.git'
+pod 'Unbox', '1.0'
 pod 'Moya'
 pod 'XCGLogger'
 pod 'Nuke'


### PR DESCRIPTION
A versão que foi colocada no `Podfile` está apontando pro **HEAD** do repositório do dono do projeto. Lá, já está na versão **1.2**.

Desde a versão **1.1**, o protocolo `UnboxTransformer` não existe mais (e está sendo usado no nosso projeto). Por enquanto, forcei a versão para **1.0** para poder ter esse cara de volta.

Mais pra frente, acho que vale inclusive repensar a utilização dessa lib, uma vez que agora estamos a SDK do Parse direto.
