### PR TITLE
Adiciona SDK do Parse e configura cocoapods-keys

### DIFF
--- a/CocoaHeadsApp/CocoaHeadsApp/AppDelegate.swift
+++ b/CocoaHeadsApp/CocoaHeadsApp/AppDelegate.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 import XCGLogger
+import Parse
+import Keys
 
 let logger = XCGLogger.defaultInstance()
 
@@ -16,8 +18,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        let keys = CocoaheadsappKeys()
+        Parse.setApplicationId(keys.parseApplicationId(), clientKey: keys.parseClientKey())
+
+        let query = PFQuery(className: "Chapter")
+        query.findObjectsInBackgroundWithBlock { (objects, error) -> Void in
+            if let chapters = objects {
+                chapters.each({ (chapter) -> Void in
+                    print(chapter["city"])
+                })
+            }
+        }
+
         logger.setup(.Debug, showLogIdentifier: false, showFunctionName: true, showThreadName: true, showLogLevel: true, showFileNames: true, showLineNumbers: true, showDate: false, writeToFile: nil, fileLogLevel: nil)
         return true
     }

--- a/CocoaHeadsApp/CocoaHeadsApp/R.generated.swift
+++ b/CocoaHeadsApp/CocoaHeadsApp/R.generated.swift
@@ -20,8 +20,8 @@ struct R {
   }
   
   struct image {
-    static var first: UIImage? { return UIImage(named: "first") }
-    static var second: UIImage? { return UIImage(named: "second") }
+    static var first: UIImage? { return UIImage(named: "first", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil) }
+    static var second: UIImage? { return UIImage(named: "second", inBundle: _R.hostingBundle, compatibleWithTraitCollection: nil) }
   }
   
   struct nib {
@@ -32,7 +32,7 @@ struct R {
   }
   
   struct reuseIdentifier {
-    static var displayMeetupCell: ReuseIdentifier<CocoaHeadsApp.MeetupListCollectionViewCell> { return ReuseIdentifier(identifier: "displayMeetupCell") }
+    static var displayMeetupCell: ReuseIdentifier<MeetupListCollectionViewCell> { return ReuseIdentifier(identifier: "displayMeetupCell") }
   }
   
   struct segue {
@@ -42,7 +42,7 @@ struct R {
   struct storyboard {
     struct launchScreen {
       static var initialViewController: UIViewController? { return instance.instantiateInitialViewController() }
-      static var instance: UIStoryboard { return UIStoryboard(name: "LaunchScreen", bundle: nil) }
+      static var instance: UIStoryboard { return UIStoryboard(name: "LaunchScreen", bundle: _R.hostingBundle) }
       
       static func validateImages() {
         
@@ -55,7 +55,7 @@ struct R {
     
     struct main {
       static var initialViewController: UITabBarController? { return instance.instantiateInitialViewController() as? UITabBarController }
-      static var instance: UIStoryboard { return UIStoryboard(name: "Main", bundle: nil) }
+      static var instance: UIStoryboard { return UIStoryboard(name: "Main", bundle: _R.hostingBundle) }
       
       static func validateImages() {
         assert(UIImage(named: "first") != nil, "[R.swift] Image named 'first' is used in storyboard 'Main', but couldn't be loaded.")
@@ -70,14 +70,16 @@ struct R {
 }
 
 struct _R {
+  static var hostingBundle: NSBundle? { return NSBundle(identifier: "br.com.cocoaheads.CocoaHeads-Apps") }
+  
   struct nib {
     struct _MeetupListCollectionViewCell: NibResource, Reusable {
-      var instance: UINib { return UINib.init(nibName: "MeetupListCollectionViewCell", bundle: nil) }
+      var instance: UINib { return UINib.init(nibName: "MeetupListCollectionViewCell", bundle: _R.hostingBundle) }
       var name: String { return "MeetupListCollectionViewCell" }
-      var reuseIdentifier: ReuseIdentifier<CocoaHeadsApp.MeetupListCollectionViewCell> { return ReuseIdentifier(identifier: "displayMeetupCell") }
+      var reuseIdentifier: ReuseIdentifier<MeetupListCollectionViewCell> { return ReuseIdentifier(identifier: "displayMeetupCell") }
       
-      func firstView(ownerOrNil: AnyObject?, options optionsOrNil: [NSObject : AnyObject]?) -> CocoaHeadsApp.MeetupListCollectionViewCell? {
-        return instantiateWithOwner(ownerOrNil, options: optionsOrNil)[0] as? CocoaHeadsApp.MeetupListCollectionViewCell
+      func firstView(ownerOrNil: AnyObject?, options optionsOrNil: [NSObject : AnyObject]?) -> MeetupListCollectionViewCell? {
+        return instantiateWithOwner(ownerOrNil, options: optionsOrNil)[0] as? MeetupListCollectionViewCell
       }
       
       func instantiateWithOwner(ownerOrNil: AnyObject?, options optionsOrNil: [NSObject : AnyObject]?) -> [AnyObject] {
@@ -86,7 +88,7 @@ struct _R {
     }
     
     struct _MeetupListView: NibResource {
-      var instance: UINib { return UINib.init(nibName: "MeetupListView", bundle: nil) }
+      var instance: UINib { return UINib.init(nibName: "MeetupListView", bundle: _R.hostingBundle) }
       var name: String { return "MeetupListView" }
       
       func firstView(ownerOrNil: AnyObject?, options optionsOrNil: [NSObject : AnyObject]?) -> UIView? {
@@ -99,7 +101,7 @@ struct _R {
     }
     
     struct _SlideListView: NibResource {
-      var instance: UINib { return UINib.init(nibName: "SlideListView", bundle: nil) }
+      var instance: UINib { return UINib.init(nibName: "SlideListView", bundle: _R.hostingBundle) }
       var name: String { return "SlideListView" }
       
       func firstView(ownerOrNil: AnyObject?, options optionsOrNil: [NSObject : AnyObject]?) -> UIView? {
@@ -112,7 +114,7 @@ struct _R {
     }
     
     struct _VideosListView: NibResource {
-      var instance: UINib { return UINib.init(nibName: "VideosListView", bundle: nil) }
+      var instance: UINib { return UINib.init(nibName: "VideosListView", bundle: _R.hostingBundle) }
       var name: String { return "VideosListView" }
       
       func firstView(ownerOrNil: AnyObject?, options optionsOrNil: [NSObject : AnyObject]?) -> UIView? {
@@ -200,6 +202,6 @@ extension UICollectionView {
 
 extension UIViewController {
   convenience init(nib: NibResource) {
-    self.init(nibName: nib.name, bundle: nil)
+    self.init(nibName: nib.name, bundle: _R.hostingBundle)
   }
 }

--- a/CocoaHeadsApp/Podfile
+++ b/CocoaHeadsApp/Podfile
@@ -1,3 +1,11 @@
+plugin 'cocoapods-keys', {
+  :project => 'CocoaHeadsApp',
+  :keys => [
+    'ParseApplicationId',
+    'ParseClientKey'
+  ]
+}
+
 platform :ios, '8.0'
 use_frameworks!
 
@@ -6,3 +14,4 @@ pod 'Unbox', :git => 'https://github.com/JohnSundell/Unbox.git'
 pod 'Moya'
 pod 'XCGLogger'
 pod 'Nuke'
+pod 'Parse'

--- a/CocoaHeadsApp/Podfile.lock
+++ b/CocoaHeadsApp/Podfile.lock
@@ -1,36 +1,40 @@
 PODS:
-  - Alamofire (3.1.2)
-  - Moya (4.4.0):
-    - Moya/Core (= 4.4.0)
-  - Moya/Core (4.4.0):
+  - Alamofire (3.1.3)
+  - Bolts/Tasks (1.5.0)
+  - Keys (1.0.0)
+  - Moya (4.5.0):
+    - Moya/Core (= 4.5.0)
+  - Moya/Core (4.5.0):
     - Alamofire (~> 3.0)
-  - Nuke (1.1.1)
-  - R.swift (0.11.0)
-  - Unbox (0.0.1)
-  - XCGLogger (3.0)
+  - Nuke (1.2.0)
+  - Parse (1.10.0):
+    - Bolts/Tasks (~> 1.5)
+  - R.swift (0.12.0)
+  - Unbox (1.0)
+  - XCGLogger (3.1.1)
 
 DEPENDENCIES:
+  - Keys (from `Pods/CocoaPodsKeys`)
   - Moya
   - Nuke
+  - Parse
   - R.swift
-  - Unbox (from `https://github.com/JohnSundell/Unbox.git`)
+  - Unbox (= 1.0)
   - XCGLogger
 
 EXTERNAL SOURCES:
-  Unbox:
-    :git: https://github.com/JohnSundell/Unbox.git
-
-CHECKOUT OPTIONS:
-  Unbox:
-    :commit: dfbe41cb8a7e00bc17e02414a9ccf7df0d02c508
-    :git: https://github.com/JohnSundell/Unbox.git
+  Keys:
+    :path: Pods/CocoaPodsKeys
 
 SPEC CHECKSUMS:
-  Alamofire: 7c16ca65f3c7e681fd925fd7f2dec7747ff96855
-  Moya: 0ade653ca4bc83bec120493130ecc32f137e5683
-  Nuke: ec41b6486f31622acedb3ca82ebf1cb7914bd472
-  R.swift: dfd7addf1564914d92745816b76b0563d688f387
-  Unbox: ff22e3cd32acb357ae82b718b28eb04f0f8c2e1a
-  XCGLogger: 5802533aff8bafc8b3b9776ab8972576f31d0a4e
+  Alamofire: 9f93b56389e48def9220dd57d1f44b1927229a5a
+  Bolts: 722ab9a4f8b50fc4ed1b9998a5a7a2b3f16d80b4
+  Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
+  Moya: 82813e5bf27564535cd9cdf4e9db61fd220f7f8e
+  Nuke: 97e515a9aae017ea03d0cebb63312642b0700409
+  Parse: 90b2544822200f84b18bfacc4e8b0a3a6c3584a2
+  R.swift: 8d8a9f0cb36462d0dff82b70cc2c0396add668fe
+  Unbox: 390bf61ea9645465a09f374533595ed6b682931b
+  XCGLogger: e111a313f609432394c3ae378d99511634fd2e3c
 
 COCOAPODS: 0.39.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 [![waffle board](https://img.shields.io/badge/waffle-board-blue.svg)](https://waffle.io/CocoaHeadsBrasil/CocoaHeadsApp)
 
-## Guidelines para desenvolver novas features do app
+## Setup inicial
+
+### cocoapods-keys
+Usamos o **cocoapods-keys** para gerenciar as chaves de acesso. Para instalar, execute:
+```
+gem install cocoapods-keys
+```
+Ambas as chaves `ParseApplicationId` e `ParseClientKey` estão configuradas. Criamos uma conta de teste para ser compartilhada. Procure saber quem as possui. Caso prefira, você também pode criar a sua própria app no Parse e utilizar suas próprias chaves de acesso.
+
+## Guidelines de desenvolvimento
 
 #### UI
 Usamos um storyboard **Main.storyboard** para definir o fluxo do app, porém o desenvolvimento da tela não é feito diretamente no storyboard. Para desenvolver uma tela você deve:


### PR DESCRIPTION
Coloquei um exemplo no `AppDelegete` mesmo só pra garantir que a chamada funciona:

``` swift
let query = PFQuery(className: "Chapter")
query.findObjectsInBackgroundWithBlock { (objects, error) -> Void in
    if let chapters = objects {
        chapters.each({ (chapter) -> Void in
            print(chapter["city"])
        })
    }
}
```

Saída:

```
Rio Branco
Maceió
Manaus
Fortaleza
Brasília
Goiânia
Belo Horizonte
Juiz de Fora
Curitiba
Recife
Teresina
Barra da Tijuca
Rio de Janeiro
Porto Alegre
Blumenau
Florianópolis
Brasil
Campinas
Jundiaí
São Paulo
Tatuí
```
