### PR TITLE
Remover instrução de instalação do parse

### DIFF
--- a/CocoaHeadsApp/Podfile
+++ b/CocoaHeadsApp/Podfile
@@ -4,7 +4,6 @@ def common_pods
     pod 'Moya', '~> 6.1.3'
     pod 'XCGLogger', '~> 3.2'
     pod 'Nuke', '~> 2.0.1'
-    pod 'Parse', '~> 1.12.0'
 end
 
 def common_test_pods


### PR DESCRIPTION
Eu criei o fork para mexer nos testes unitários antes da remoção do parse do projeto. Após o rebase, a instrução da dependência ficou no podifle. Este é PR para removê-lo.
