### PR TITLE
added more description to the dependecy install process on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ CocoaHeads é um grupo formado por desenvolvedores (profissionais e iniciantes),
 ### Instalação das Dependências
 
 ```
+gem install bundler
 bundle install
+cd CocoaHeadsApp
+pod install
 ```
 
 


### PR DESCRIPTION
Não estava claro que era precisava ter o bundler pra instalar o Cocoapods-acknowledgements
