### PR TITLE
Refatorando setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,25 +1,39 @@
 #!/bin/bash
 
-echo "Instaling Bundler"
-gem install bundler
-bundle install
+# Tells the shell script to exit if it encounters an error
+set -e
 
-echo "Instaling or Updating Homebrew"
-which -s brew
-if [[ $? != 0 ]] ; then
-    # Install Homebrew
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+# -- Log -----------------------------------------------------------------------
+function msg { echo  "\033[0;37m$1\033[0m"; }
+function msg_ok { echo  "➜\033[1;32m $1 ✔\033[0m"; }
+function msg_run { echo  "➜\033[1;35m $1 $ $2\033[0m"; }
+
+# -- Dependencies --------------------------------------------------------------
+msg "Instaling Bundler!"
+if which ruby &> /dev/null; then
+	msg_run "bundler" "sudo gem install bundler"
+	sudo gem install bundler
 else
-    brew update
+	msg_run "bundler" "gem install bundler"
+	gem install bundler
 fi
 
-echo "Instaling or Updating Swiftlint"
+msg "Installing Homebrew!"
+if which brew &> /dev/null; then
+	msg_ok "homebrew"
+else
+	msg_run "homebrew" "/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)""
+	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+
+msg "Instaling/Updating Swiftlint"
 which -s swiftlint
-if [[ $? != 0 ]] ; then
-    brew install swiftlint
+if [[ $? != 1 ]] ; then
+    msg_ok "swiftlint"
 else
-    brew upgrade swiftlint
+    msg_run "swiftlint" "brew install swiftlint"
+    brew install swiftlint
 fi
 
-echo "Executing CocoaPods"
-cd CocoaHeadsApp && pod install && cd ..
+msg "Executing CocoaPods"
+bundle exec pod install


### PR DESCRIPTION
Detalhes:
- Em algumas máquinas, é necessário incluir `sudo` para instalar bundler.
- O link para download do Homebrew foi atualizado para o que é recomendado no [brew.sh](http://brew.sh/)
- Funções para customizar o output durante execução do script no terminal
- Sobre a parte do Cocoapods: se pelo README é recomendado executar o script desta forma: `./setup.sh`. Então, é considerado que já estamos dentro da pasta CocoaHeadsApp. Portanto, não é necessário o `cd`. 
